### PR TITLE
scinsight: Try to match on log path as dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ options:
   -h, --help            show this help message and exit
   -o OUTDIR, --outdir OUTDIR
                         output directory
-  -l LOG, --log LOG     log file prefix
+  -l LOG, --log LOG     log file prefix, or path to directory containing log files
   -q, --quiet           do not print result to stdout
 ```
 

--- a/bin/scinsight
+++ b/bin/scinsight
@@ -27,7 +27,18 @@ def get_syscall_name(line):
     return syscall
 
 def get_strace_names(odir, log):
-    logs = os.path.join(odir, log + "-scmon.") + '*'
+    prefix = os.path.join(odir, log)
+    #
+    # Match only prefix-scmon.* files.
+    # 1. /path/to/prefix-scmon*
+    #
+    # Treat /path/to/prefix as a directory, and match any *-scmon.* files
+    # inside of it.
+    # 2. /path/to/prefix/*-scmon.*
+    #
+    logs = prefix + '-scmon.*'
+    if not glob.glob(logs):
+        logs = os.path.join(prefix, '*-scmon.*')
     return logs
 
 def syscall_stat(odir, log):
@@ -106,7 +117,7 @@ def get_cmd_options(argv):
     parser.add_argument('-o', '--outdir', action='store', required=True,
                         help='output directory') 
     parser.add_argument('-l', '--log', action='store', required=True,
-                        help='log file prefix' ) 
+                        help='log file prefix, or path to directory containing log files')
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='do not print result to stdout' ) 
 


### PR DESCRIPTION
In scinsight, when matching trying to find log files emitted by scmon according to the --log argument, we do a hard match on /path/to/log-scmon*. It seems like it would be a somewhat typical / intuitive use case to have scmon emit logs to some directory, and for a user to want to just pass a file to the directory and have scinsight find them automatically.

Let's update get_strace_names() to also try to match by log-directory prefix. Note that this will break users who always output to the same output directory, but with different log file prefixes.

**NOTE**: As mentioned above, this may break some users if they run `scmon` multiple times to output logs to the same output directory but with different log prefixes. If that's a concern, we can either:

1. Add another option to toggle this behavior
2. Drop the PR