### PR TITLE
procinsight: Account for missing perf counters

### DIFF
--- a/bin/procinsight
+++ b/bin/procinsight
@@ -46,7 +46,9 @@ def report_stat_in_csv(col_names, stat_ll, f):
         print("{0:<20}".format(key), end=", ", file = f)
         for c in range(ncol):
             _, val= stat_ll[r][c]
-            if is_float(val):
+            if val is None:
+                print("{0:>20}".format("%s" % "N/A"), end=get_sep(c, ncol), file = f)
+            elif is_float(val):
                 print("{0:>20}".format("%.4f" % val), end=get_sep(c, ncol), file = f)
             else:
                 print("{0:>20}".format(int(val)), end=get_sep(c, ncol), file = f)
@@ -241,7 +243,7 @@ def parse_log_ef(log, parse_tbl):
     # sort statistics for easier interpretation
     stat2 = []
     for key, (pos, name) in parse_tbl:
-        stat2.append( (name, stat[name]) )
+        stat2.append( (name, stat.get(name)) )
     return stat2
 
 def procmon_stat_energy(args):


### PR DESCRIPTION
On some platforms, not all perf counters will be available that procinsight is expecting. For example, on AMD, we can't see the backend stall %, as shown here:

[void@maniforge scx]$ sudo perf stat -a -- sleep 1

 Performance counter stats for 'system wide':

          32094.27 msec cpu-clock                        #   31.992 CPUs utilized
              8703      context-switches                 #  271.170 /sec
               136      cpu-migrations                   #    4.238 /sec
             42172      page-faults                      #    1.314 K/sec
        2054519977      cycles                           #    0.064 GHz
         707776754      stalled-cycles-frontend          #   34.45% frontend cycles idle
        1604144773      instructions                     #    0.78  insn per cycle
                                                  #    0.44  stalled cycles per insn
         326035070      branches                         #   10.159 M/sec
          19402290      branch-misses                    #    5.95% of all branches

       1.003192165 seconds time elapsed

Let's update the script to gracefully handle missing perf counters.