### PR TITLE
MangoHud.conf: Set log interval to zero.

### DIFF
--- a/config/MangoHud.conf
+++ b/config/MangoHud.conf
@@ -230,7 +230,7 @@ frame_timing
 ### Set amount of time in seconds that the logging will run for
 # log_duration=
 ### Change the default log interval, 100 is default
-# log_interval=100
+log_interval=0
 ### Set location of the output files (required for logging)
 output_folder=/home/deck/mangologs-vapormark
 ### Permit uploading logs directly to FlightlessMango.com


### PR DESCRIPTION
Batching the logging is good for the throughput but bad for the tail latency, so it can impact the tail latency results. Hence, let's set the log interval to zero.